### PR TITLE
live refresh of local edits of crossplane docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 # Run jekyll in development mode
+
+LOCAL_DOCS_DIR := docs/local
+
 run: _data/versions.json
 	docker run --rm -it \
 		-p 4000:4000 -p 4001:4001 \
@@ -6,6 +9,16 @@ run: _data/versions.json
 		-v "$(PWD):/srv/jekyll" \
 		jekyll/jekyll -- \
 		jekyll serve --livereload --livereload-port 4001
+
+run_docs_local: local_docs_dir _data/versions.json
+	docker run --rm -it \
+		-p 4000:4000 -p 4001:4001 \
+		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
+		-v "$(PWD):/srv/jekyll" \
+		-v "$(GOPATH)/src/github.com/crossplaneio/crossplane/docs:/srv/jekyll/$(LOCAL_DOCS_DIR)" \
+		jekyll/jekyll -- \
+		jekyll serve --livereload --livereload-port 4001
+	rm -d $(LOCAL_DOCS_DIR)
 
 # Build (output is in _site)
 build: _data/versions.json
@@ -38,3 +51,8 @@ _data/versions.json: node_modules docs
 node_modules: package.json package-lock.json
 	npm install
 	@touch node_modules
+
+# Create the local docs dir needed before _data/versions.json in some cases
+local_docs_dir: 
+	mkdir -p $(LOCAL_DOCS_DIR)
+

--- a/README.md
+++ b/README.md
@@ -7,5 +7,20 @@ This is the the source for http://crossplane.io. It is rendered using [Jekyll](h
 This runs locally watching for changes and live reloading.
 
 ```
+brew install npm
+
 make run
 ```
+
+Open http://localhost:4000 in your browser.
+
+## To run locally with local crossplane docs
+Ensure `$(GOPATH)/src/github.com/crossplaneio/crossplane/docs` is present.
+
+```
+brew install npm
+
+make run_docs_local
+```
+
+Open http://localhost:4000 in your browser.

--- a/preprocess.js
+++ b/preprocess.js
@@ -16,13 +16,28 @@ function getDirectories(srcpath) {
 
 const ROOT_DIR = `${__dirname}`;
 
+// This version map and version function allow versions that do not follow semver syntax to also
+// be included in the version selection sorting for the site.  "local" is the developer version
+// used when testing docs changes in a local development environment.  We set this "local"
+// version as 7.7.7 (a high value) so that it will show up as the "latest" version in the site's
+// version selection dropdown.
+const versionMap = new Map([
+  ["local", "7.7.7"]
+])
+function version(v) {
+  if (versionMap.has(v)){
+    return versionMap.get(v)
+  }
+  return semver.coerce(v).version
+}
+
 // collect all docs versions (forcing master to the end)
 const data = [];
 const versions = [
   ...getDirectories(`${ROOT_DIR}/docs`)
     .filter(v => v !== "master")
     .sort((a, b) =>
-      semver.rcompare(semver.coerce(a).version, semver.coerce(b).version)
+      semver.rcompare(version(a), version(b))
     ),
   "master"
 ];


### PR DESCRIPTION
Updated the readme.md with the trick that @suskin uses for live refresh of local crossplane docs edits.

![image](https://user-images.githubusercontent.com/284840/64901290-6e6ce680-d64c-11e9-95cc-1a62d94e8e86.png)
