### PR TITLE
Capitalize 'Crossplane' and 'Kubernetes' since they are proper nouns

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ stylesheet: index
         <div>
           <h1>The open source multicloud control plane.</h1>
           <p>
-            Manage your cloud-native applications and infrastructure across 
+            Manage your cloud-native applications and infrastructure across
             environments, clusters, regions and clouds.
           </p>
           <button onclick="window.location.href='{{ githubLink }}'">
@@ -37,7 +37,7 @@ stylesheet: index
       <div class="col-6_md-12">
         <h2>Provision the managed services your applications depend on using ‘kubectl.’</h2>
         <p>
-          Securely consume managed services such as PostgreSQL, Redis, Buckets and more, from 
+          Securely consume managed services such as PostgreSQL, Redis, Buckets and more, from
           your choice of cloud on-premises.
           <img src="{{ "/images/quad-red-medium.svg" | relative_url }}" />
         </p>
@@ -65,7 +65,7 @@ stylesheet: index
       <div class="col-6_md-12">
         <h2>Schedule workloads across clusters, regions and clouds.</h2>
         <p>
-          Define complete applications with managed service dependencies for scheduling across 
+          Define complete applications with managed service dependencies for scheduling across
           clusters and regions to balance reliability, cost, and performance.
           <img src="{{ "/images/quad-red-medium.svg" | relative_url }}" />
         </p>
@@ -75,7 +75,7 @@ stylesheet: index
       <div class="col-6_md-12">
         <h2>Manage multiple clusters from a single control plane.</h2>
         <p>
-          Provision and manage kubernetes clusters: bring your own clusters or generate on demand, 
+          Provision and manage Kubernetes clusters: bring your own clusters or generate on demand,
           with common configuration and policy.
           <img src="{{ "/images/quad-red-medium.svg" | relative_url }}" />
         </p>
@@ -118,8 +118,8 @@ stylesheet: index
       </div>
       <div class="blueprint-item col-11_xs-10">
         <h3>A strong separation of concerns.</h3>
-        <p>Developers can define workloads without worrying about implementation details, 
-          environment constraints, or policies. Administrators can define environment specifics, 
+        <p>Developers can define workloads without worrying about implementation details,
+          environment constraints, or policies. Administrators can define environment specifics,
           and policies. Enable a higher degree of reusability and reduce complexity.</p>
       </div>
       <div class="blueprint-bullet col-1_xs-2">
@@ -137,7 +137,7 @@ stylesheet: index
       <div class="blueprint-item col-11_xs-10">
         <h3>Open source that doesn’t have an agenda.</h3>
         <p>Crossplane is open source software released under the Apache 2.0 license. Crossplane is
-           a true community-driven effort to define a control plane that can span multiple cloud 
+           a true community-driven effort to define a control plane that can span multiple cloud
            providers, many regions and offerings.</p>
       </div>
       <div class="blueprint-bullet col-1_xs-2">
@@ -146,7 +146,7 @@ stylesheet: index
       <div class="blueprint-item col-11_xs-10">
         <h3>Built with high levels of extensibility.</h3>
         <p>Leverages tried and tested Kubernetes machinery to provide a high level of extensibility
-           around APIs, resource controllers, schedulers and other components. This empowers the 
+           around APIs, resource controllers, schedulers and other components. This empowers the
            community to build on top of it easily.</p>
       </div>
       <div class="blueprint-bullet col-1_xs-2">
@@ -154,8 +154,8 @@ stylesheet: index
       </div>
       <div class="blueprint-item col-11_xs-10">
         <h3>Full lifecycle management of resources.</h3>
-        <p>A resource controller is responsible for the entire lifecycle of a resource. This 
-          resource is responsible for provisioning, health, scaling, failover, and actively 
+        <p>A resource controller is responsible for the entire lifecycle of a resource. This
+          resource is responsible for provisioning, health, scaling, failover, and actively
           responding to external changes that deviate from the desired configuration.</p>
       </div>
     </div>
@@ -188,7 +188,7 @@ stylesheet: index
           <div class="exec-info">
             <div class="name">Sid Sijbrandij</div>
             <div class="title">CEO and Co-Founder of GitLab</div>
-          </div>          
+          </div>
         </div>
       </div>
       <div class="testimonial col-6_md-12">
@@ -210,7 +210,7 @@ stylesheet: index
           <div class="exec-info">
             <div class="name">Spencer Kimball</div>
             <div class="title">CEO and Founder of Cockroach Labs</div>
-          </div>          
+          </div>
         </div>
       </div>
       <div class="testimonial col-6_md-12">
@@ -229,7 +229,7 @@ stylesheet: index
           <div class="exec-info">
             <div class="name">Karthik Ranganathan</div>
             <div class="title">Co-Founder and CTO of Yugabyte</div>
-          </div>          
+          </div>
         </div>
       </div>
       <div class="testimonial col-6_md-12">
@@ -251,7 +251,7 @@ stylesheet: index
           <div class="exec-info">
               <div class="name">Bassam Tabbara</div>
               <div class="title">CEO and Founder of Upbound</div>
-          </div>          
+          </div>
         </div>
       </div>
     </div>
@@ -264,7 +264,7 @@ stylesheet: index
       <div class="col-10_sm-12">
         <h2>Learn more and get involved with the community</h2>
         <p>
-          Join the conversation and help shape the evolution of crossplane. Here
+          Join the conversation and help shape the evolution of Crossplane. Here
           are a few ways to get started.
         </p>
       </div>
@@ -303,7 +303,7 @@ stylesheet: index
           </div>
         </div>
       </div>
-      <div class="col-3_md-6_xs-12 tile"> 
+      <div class="col-3_md-6_xs-12 tile">
         <div class="youtube">
           <div class="topbar"></div>
           <div class="content">


### PR DESCRIPTION
In addition to capitalization of proper nouns, extraneous whitespace was removed.